### PR TITLE
fix for #170

### DIFF
--- a/sitejs/verify.js
+++ b/sitejs/verify.js
@@ -17,7 +17,7 @@ resend.addEventListener('mousedown', async () => {
     if(success) resendSuccess.innerHTML = "We sent you another verification email.";
     else if(!success) {
         resendSuccess.innerHTML = "";
-        if(err == 'timeout') window.SHOW_ERROR("You can only send a verification email every 5 minutes. Wait less than 5 minutes...");
+        if(err == 'timeout') window.SHOW_ERROR("You can only resend the verification email every 5 minutes. Wait less than 5 minutes...");
         else window.SHOW_ERROR("Looks like there's something wrong on our side. Try again later.");
     }
 });
@@ -27,6 +27,9 @@ changeEmailBtn.addEventListener('mousedown', async () => {
     else {
         changeSuccess.innerHTML = "";
         switch(err) {
+            case 'timeout':
+                window.SHOW_ERROR("You can only change your email every 5 minutes. Wait less than 5 minutes...");
+            break;
             case 'invalid pwd':
                 window.SHOW_ERROR("Wrong password.");
             break;
@@ -37,6 +40,7 @@ changeEmailBtn.addEventListener('mousedown', async () => {
                 window.SHOW_ERROR("That email is already taken.");
             break;
             default:
+                console.log(err);
                 window.SHOW_ERROR("Looks like there's something wrong on our side. Try again later.");
             break;
         }


### PR DESCRIPTION
Description: there was no bug in the first place, but because the redis handling was commented out, the lack of redis caused the server to panic when changing the user's email (because it had to resend a verification email and it had to make sure the user wasn't spamming the servers).

However, there has been updates to error handling so that the user sees the appropriate error message rather than "Looks like there's an issue on our side".